### PR TITLE
Defines comments font-size

### DIFF
--- a/stylesheets/shared/_codesplit.scss
+++ b/stylesheets/shared/_codesplit.scss
@@ -22,7 +22,7 @@
             float: right;
             width: 43%;
             padding: .2em 0 0 0;
-            p { margin: 0; }
+            p { margin: 0; font-size: $font-XS; }
         }
     }
 


### PR DESCRIPTION
Sets the `font-size` property of the .codesplit .comment explicitly for HTML. Matches the pdf rendering view