### PR TITLE
updated magicbook codesplit and katex versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,8 @@
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
-    "magicbook-codesplit": "^0.1.6",
-    "magicbook-katex": "0.0.7",
-    "magicbook-webpack": "0.0.3",
+    "magicbook-codesplit": "^0.1.7",
+    "magicbook-katex": "0.0.8",
     "through2": "^3.0.1"
   }
 }


### PR DESCRIPTION
Updates the magicbook plugin version dependencies for codesplit and katex - related to: https://github.com/nature-of-code/noc-book-2/pull/56#issuecomment-514211320 

Note, to re-install magicbook once the latest version is published to npm https://github.com/nature-of-code/noc-book-2/pull/56#issuecomment-514211320 