### PR TITLE
Typo fix: calcFitness -> fitness

### DIFF
--- a/content/09_ga.html
+++ b/content/09_ga.html
@@ -1042,7 +1042,7 @@ function draw() {
 
     //{!1} n is equal to fitness times 100,
     // which leaves me with an integer between 0 and 100.
-    let n = int(population[i].calcFitness * 100);
+    let n = int(population[i].fitness * 100);
     for (let j = 0; j < n; j++) {
       //{!1} Add each member of the population
       // to the mating pool N times.


### PR DESCRIPTION
Hi! calcFitness is the name of a method in class DNA, it should be changed to the member variable fitness. (content/09_ga.html line 1045)
